### PR TITLE
hdr script now prints all

### DIFF
--- a/script/analysis/hdr.py
+++ b/script/analysis/hdr.py
@@ -1,27 +1,27 @@
 import hdf5_to_dict as io
 import sys
 
+preferred_keys = ['N1','N2','N3',
+                  'a',
+                  'M_unit','B_unit','L_unit','Ne_unit']
+
 if len(sys.argv) != 2:
   print('ERROR format is')
   print('  python hdr.py [filename]')
   sys.exit()
 
 fnam = sys.argv[1]
-
 hdr = io.load_hdr(fnam)
 
-#print(hdr.keys())
-
+used_keys = []
 def print_val(vnam):
-  if vnam in hdr.keys():
-    print(vnam,'=','%e' % hdr[vnam])
+  if vnam in hdr.keys() and vnam not in used_keys:
+    format_string = '%e' if type(hdr[vnam]) is float else '%s'
+    print(vnam,'=',format_string % hdr[vnam])
+    used_keys.append(vnam)
 
-print_val('N1')
-print_val('N2')
-print_val('N3')
-print_val('a')
-print_val('M_unit')
-print_val('B_unit')
-print_val('L_unit')
-print_val('Ne_unit')
+for k in preferred_keys:
+  print_val(k)
 
+for k in hdr.keys():
+  print_val(k)


### PR DESCRIPTION
I modified the `hdr.py` script so that the variables in `preferred_keys` are printed first, but then all header variables are printed.