### PR TITLE
Move `snap.py` to use `argparse`

### DIFF
--- a/script/analysis/movie.py
+++ b/script/analysis/movie.py
@@ -25,16 +25,11 @@ parser.add_argument('--coords',type=str,
 parser.add_argument('-s','--size',
                     type=float,default=40,
                     help='Size of domain to plot')
-parser.add_argument('--log',
-                    dest='log',
-                    default=True,
-                    action='store_true',
-                    help='Turns log scale on')
-parser.add_argument('--no-log',
+parser.add_argument('--lin',
                     dest='log',
                     default=True,
                     action='store_false',
-                    help='Turns log scale off')
+                    help='Sets scale to linear. Default is log.')
 parser.add_argument('--vmin',
                     type=float,default=-4,
                     help='Colormap lower bound')

--- a/script/analysis/movie.py
+++ b/script/analysis/movie.py
@@ -25,9 +25,16 @@ parser.add_argument('--coords',type=str,
 parser.add_argument('-s','--size',
                     type=float,default=40,
                     help='Size of domain to plot')
-parser.add_argument('-l','--log',
-                    type=bool,default=True,
-                    help='Log scale?')
+parser.add_argument('--log',
+                    dest='log',
+                    default=True,
+                    action='store_true',
+                    help='Turns log scale on')
+parser.add_argument('--no-log',
+                    dest='log',
+                    default=True,
+                    action='store_false',
+                    help='Turns log scale off')
 parser.add_argument('--vmin',
                     type=float,default=-4,
                     help='Colormap lower bound')
@@ -37,6 +44,9 @@ parser.add_argument('--vmax',
 parser.add_argument('-c','--cmap',
                     type=str,default='jet',
                     help='Colormap used')
+parser.add_argument('--label',
+                    type=str,default=None,
+                    help='Label for colormap')
 
 args = parser.parse_args()
 
@@ -60,11 +70,10 @@ def make_frame(pair):
   make_snap(d,args.variable,args.coords,
             args.size,args.cmap,args.log,
             os.path.join(tmpdir,'frame_%08d.png' % i),
+            args.label,
             args.vmin,args.vmax,
             geom=geom)
 
-# for pair in enumerate(dfnams):
-#   make_frame(pair)
 p = Pool()
 p.map(make_frame,enumerate(dfnams))
 

--- a/script/analysis/snap.py
+++ b/script/analysis/snap.py
@@ -23,9 +23,16 @@ parser.add_argument('--coords',type=str,
 parser.add_argument('-s','--size',
                     type=float,default=40,
                     help='Size of domain to plot')
-parser.add_argument('-l','--log',
-                    type=bool,default=True,
-                    help='Log scale?')
+parser.add_argument('--log',
+                    dest='log',
+                    default=True,
+                    action='store_true',
+                    help='Turns log scale on')
+parser.add_argument('--no-log',
+                    dest='log',
+                    default=True,
+                    action='store_false',
+                    help='Turns log scale off')
 parser.add_argument('--vmin',
                     type=float,default=-4,
                     help='Colormap lower bound')
@@ -38,8 +45,13 @@ parser.add_argument('-c','--cmap',
 parser.add_argument('--save',
                     type=str,default=None,
                     help='Figure filename if you want to save the figure')
+parser.add_argument('--label',
+                    type=str,default=None,
+                    help='Label for colormap')
 
-def make_snap(dfnam,vnam,coords,size,cmap,logplot,savefig,vmin,vmax,
+def make_snap(dfnam,vnam,coords,size,cmap,logplot,
+              savefig,label,
+              vmin,vmax,
               geom=None):
 
   if not os.path.exists(dfnam):
@@ -64,8 +76,12 @@ def make_snap(dfnam,vnam,coords,size,cmap,logplot,savefig,vmin,vmax,
 
   IS_3D = hdr['N3'] > 1
 
+  if label is None:
+    label = vnam
+
   var = dump[vnam]
   if logplot:
+    print("logplot")
     var = np.log10(var)
 
   if IS_3D:
@@ -76,29 +92,29 @@ def make_snap(dfnam,vnam,coords,size,cmap,logplot,savefig,vmin,vmax,
     ax = a0
     if coords == 'mks':
       bplt.plot_X1X2(ax, geom, var, dump, cmap=cmap, vmin=vmin, vmax=vmax, 
-        cbar=False, label=vnam, ticks=None, shading='gouraud')
+        cbar=False, label=label, ticks=None, shading='gouraud')
     elif coords == 'cart':
       bplt.plot_xz(ax, geom, var, dump, cmap=cmap, vmin=vmin, vmax=vmax,
-        cbar=False, label=vnam, ticks=None, shading='gouraud')
+        cbar=False, label=label, ticks=None, shading='gouraud')
       ax.set_xlim([-size,size]); ax.set_ylim([-size,size])
     ax = a1
     if coords == 'mks':
       bplt.plot_X1X3(ax, geom, var, dump, cmap=cmap, vmin=vmin, vmax=vmax, 
-        cbar=True, label=vnam, ticks=None, shading='gouraud')
+        cbar=True, label=label, ticks=None, shading='gouraud')
     elif coords == 'cart':
       bplt.plot_xy(ax, geom, var, dump, cmap=cmap, vmin=vmin, vmax=vmax,
-        cbar=True, label=vnam, ticks=None, shading='gouraud')
+        cbar=True, label=label, ticks=None, shading='gouraud')
       ax.set_xlim([-size,size]); ax.set_ylim([-size,size])
       
   else:
     if coords == 'mks':
       fig, ax = plt.subplots(1, 1, figsize=(10, 10))
       bplt.plot_X1X2(ax, geom, var, dump, cmap=cmap, vmin=vmin, vmax=vmax,
-        cbar=True, label=vnam, ticks=None, shading='gouraud')
+        cbar=True, label=label, ticks=None, shading='gouraud')
     elif coords == 'cart':
       fig, ax = plt.subplots(1, 1, figsize=(7, 10))
       bplt.plot_xz(ax, geom, var, dump, cmap=cmap, vmin=vmin, vmax=vmax,
-        cbar=True, label=vnam, ticks=None, shading='gouraud')
+        cbar=True, label=label, ticks=None, shading='gouraud')
       ax.set_xlim([0,size]); ax.set_ylim([-size,size])
 
   if savefig == False:
@@ -119,6 +135,7 @@ if __name__ == "__main__":
   cmap = args.cmap
   logplot = args.log
   savefig = args.save if args.save is not None else False
+  label = args.label
   vmin,vmax = args.vmin,args.vmax
 
-  make_snap(dfnam,vnam,coords,size,cmap,logplot,savefig,vmin,vmax)  
+  make_snap(dfnam,vnam,coords,size,cmap,logplot,savefig,label,vmin,vmax)  

--- a/script/analysis/snap.py
+++ b/script/analysis/snap.py
@@ -1,123 +1,124 @@
+#!/usr/bin/env python
+
 import matplotlib
 import matplotlib.pyplot as plt
 import plot as bplt
 import sys, os
 import hdf5_to_dict as io
 import numpy as np
+import sys
 font = {'size' : 16}
 matplotlib.rc('font', **font)
 
-if len(sys.argv) < 3:
-  print('ERROR Format is')
-  print('  snap.py [dumpfile] [variable] [coords=cart/mks] [size=40] [log=True] [vmin=-3] [vmax=3] [cmap=jet] [savefig=False]')
-  sys.exit()
+from argparse import ArgumentParser
+parser = ArgumentParser(
+  description='Plot 2d slices of your simulation at a given time.')
+parser.add_argument('dumpfile',type=str,
+                    help='File name to plot')
+parser.add_argument('variable',type=str,
+                    help='Variable to plot')
+parser.add_argument('--coords',type=str,
+                    choices=['cart','mks'],default='cart',
+                    help='Coordinate system. Cartesian or Modified Kerr-Schild')
+parser.add_argument('-s','--size',
+                    type=float,default=40,
+                    help='Size of domain to plot')
+parser.add_argument('-l','--log',
+                    type=bool,default=True,
+                    help='Log scale?')
+parser.add_argument('--vmin',
+                    type=float,default=-4,
+                    help='Colormap lower bound')
+parser.add_argument('--vmax',
+                    type=float,default=0,
+                    help='Colormap upper bound')
+parser.add_argument('-c','--cmap',
+                    type=str,default='jet',
+                    help='Colormap used')
+parser.add_argument('--save',
+                    type=str,default=None,
+                    help='Figure filename if you want to save the figure')
 
-dfnam = sys.argv[1]
-if not os.path.exists(dfnam):
-  print('ERROR File ' + dfnam + ' does not exist!')
-  sys.exit()
+def make_snap(dfnam,vnam,coords,size,cmap,logplot,savefig,vmin,vmax,
+              geom=None):
 
-hdr = io.load_hdr(dfnam)
-geom = io.load_geom(hdr)
-dump = io.load_dump(dfnam)
+  if not os.path.exists(dfnam):
+    print('ERROR File ' + dfnam + ' does not exist!')
+    sys.exit()
 
-vnam = sys.argv[2]
-if not vnam in dump.keys():
-  print('ERROR Variable ' + vnam + ' is not contained in dump file!')
-  print('Available variables are:')
-  for key in dump.keys():
-    if type(dump[key]) is np.ndarray:
-      if (len(dump[key].shape) == 3 and dump[key].shape[0] == hdr['N1'] and
-          dump[key].shape[1] == hdr['N2'] and dump[key].shape[2] == hdr['N3']):
-        print(key, end=' ')
-  print('')
-  sys.exit()
+  hdr = io.load_hdr(dfnam)
+  if geom is None:
+    geom = io.load_geom(hdr)
+  dump = io.load_dump(dfnam,geom=geom)
 
-coords = 'cart'
-for arg in sys.argv:
-  if arg.startswith('coords='):
-    coords = str(arg[7:])
-    if coords not in ['cart', 'mks']:
-      print('ERROR Coordinates ' + coords + ' are not supported!')
-      print('Available coordinates are:')
-      print('  cart mks')
-      sys.exit()
+  if not vnam in dump.keys():
+    print('ERROR Variable ' + vnam + ' is not contained in dump file!')
+    print('Available variables are:')
+    for key in dump.keys():
+      if type(dump[key]) is np.ndarray:
+        if (len(dump[key].shape) == 3 and dump[key].shape[0] == hdr['N1'] and
+            dump[key].shape[1] == hdr['N2'] and dump[key].shape[2] == hdr['N3']):
+          print(key, end=' ')
+    print('')
+    sys.exit()
 
-size = 40
-for arg in sys.argv:
-  if arg.startswith('size='):
-    size = float(arg[5:])
+  IS_3D = hdr['N3'] > 1
 
-cmap = 'jet'
-for arg in sys.argv:
-  if arg.startswith('cmap='):
-    cmap = str(arg[5:])
+  var = dump[vnam]
+  if logplot:
+    var = np.log10(var)
 
-logplot = True
-for arg in sys.argv:
-  if arg.startswith('log='):
-    if arg[4:] == 'False' or arg[4:] == 'false' or not bool(arg[4:]):
-      logplot = False
+  if IS_3D:
+    if coords == 'mks':
+      fig, (a0, a1) = plt.subplots(1,2,gridspec_kw={'width_ratios':[1,1]}, figsize=(12,6))
+    elif coords == 'cart':
+      fig, (a0, a1) = plt.subplots(1,2,gridspec_kw={'width_ratios':[1,1]}, figsize=(13,7))
+    ax = a0
+    if coords == 'mks':
+      bplt.plot_X1X2(ax, geom, var, dump, cmap=cmap, vmin=vmin, vmax=vmax, 
+        cbar=False, label=vnam, ticks=None, shading='gouraud')
+    elif coords == 'cart':
+      bplt.plot_xz(ax, geom, var, dump, cmap=cmap, vmin=vmin, vmax=vmax,
+        cbar=False, label=vnam, ticks=None, shading='gouraud')
+      ax.set_xlim([-size,size]); ax.set_ylim([-size,size])
+    ax = a1
+    if coords == 'mks':
+      bplt.plot_X1X3(ax, geom, var, dump, cmap=cmap, vmin=vmin, vmax=vmax, 
+        cbar=True, label=vnam, ticks=None, shading='gouraud')
+    elif coords == 'cart':
+      bplt.plot_xy(ax, geom, var, dump, cmap=cmap, vmin=vmin, vmax=vmax,
+        cbar=True, label=vnam, ticks=None, shading='gouraud')
+      ax.set_xlim([-size,size]); ax.set_ylim([-size,size])
+      
+  else:
+    if coords == 'mks':
+      fig, ax = plt.subplots(1, 1, figsize=(10, 10))
+      bplt.plot_X1X2(ax, geom, var, dump, cmap=cmap, vmin=vmin, vmax=vmax,
+        cbar=True, label=vnam, ticks=None, shading='gouraud')
+    elif coords == 'cart':
+      fig, ax = plt.subplots(1, 1, figsize=(7, 10))
+      bplt.plot_xz(ax, geom, var, dump, cmap=cmap, vmin=vmin, vmax=vmax,
+        cbar=True, label=vnam, ticks=None, shading='gouraud')
+      ax.set_xlim([0,size]); ax.set_ylim([-size,size])
 
-savefig = False
-for arg in sys.argv:
-  if arg.startswith('savefig='):
-    if bool(arg[8:]) == False or arg[8:] == 'false':
-      savefig = False
-    else:
-      savefig = arg[8:]
+  if savefig == False:
+    plt.show()
+  else:
+    plt.savefig(savefig,bbox_inches='tight')
+  plt.cla()
+  plt.clf()
+  plt.close()
 
-vmin = -3; vmax = 3
-if vnam == 'RHO' and logplot:
-  vmin = -4; vmax = 0
-for arg in sys.argv:
-  if arg.startswith('vmin='):
-    vmin = float(arg[5:])
-  if arg.startswith('vmax='):
-    vmax = float(arg[5:])
+if __name__ == "__main__":
+  args = parser.parse_args()
 
-IS_3D = hdr['N3'] > 1
+  dfnam = args.dumpfile
+  vnam = args.variable
+  coords = args.coords
+  size = args.size
+  cmap = args.cmap
+  logplot = args.log
+  savefig = args.save if args.save is not None else False
+  vmin,vmax = args.vmin,args.vmax
 
-var = dump[vnam]
-if logplot:
-  var = np.log10(var)
-
-if IS_3D:
-  if coords == 'mks':
-    fig, (a0, a1) = plt.subplots(1,2,gridspec_kw={'width_ratios':[1,1]}, figsize=(12,6))
-  elif coords == 'cart':
-    fig, (a0, a1) = plt.subplots(1,2,gridspec_kw={'width_ratios':[1,1]}, figsize=(13,7))
-  ax = a0
-  if coords == 'mks':
-    bplt.plot_X1X2(ax, geom, var, dump, cmap=cmap, vmin=vmin, vmax=vmax, 
-      cbar=False, label=vnam, ticks=None, shading='gouraud')
-  elif coords == 'cart':
-    bplt.plot_xz(ax, geom, var, dump, cmap=cmap, vmin=vmin, vmax=vmax,
-      cbar=False, label=vnam, ticks=None, shading='gouraud')
-    ax.set_xlim([-size,size]); ax.set_ylim([-size,size])
-  ax = a1
-  if coords == 'mks':
-    bplt.plot_X1X3(ax, geom, var, dump, cmap=cmap, vmin=vmin, vmax=vmax, 
-      cbar=True, label=vnam, ticks=None, shading='gouraud')
-  elif coords == 'cart':
-    bplt.plot_xy(ax, geom, var, dump, cmap=cmap, vmin=vmin, vmax=vmax,
-      cbar=True, label=vnam, ticks=None, shading='gouraud')
-    ax.set_xlim([-size,size]); ax.set_ylim([-size,size])
-
-else:
-  if coords == 'mks':
-    fig, ax = plt.subplots(1, 1, figsize=(10, 10))
-    bplt.plot_X1X2(ax, geom, var, dump, cmap=cmap, vmin=vmin, vmax=vmax,
-      cbar=True, label=vnam, ticks=None, shading='gouraud')
-  elif coords == 'cart':
-    fig, ax = plt.subplots(1, 1, figsize=(7, 10))
-    bplt.plot_xz(ax, geom, var, dump, cmap=cmap, vmin=vmin, vmax=vmax,
-      cbar=True, label=vnam, ticks=None, shading='gouraud')
-    ax.set_xlim([0,size]); ax.set_ylim([-size,size])
-
-
-if savefig == False:
-  plt.show()
-else:
-  plt.savefig(savefig)
-
+  make_snap(dfnam,vnam,coords,size,cmap,logplot,savefig,vmin,vmax)  

--- a/script/analysis/snap.py
+++ b/script/analysis/snap.py
@@ -23,16 +23,11 @@ parser.add_argument('--coords',type=str,
 parser.add_argument('-s','--size',
                     type=float,default=40,
                     help='Size of domain to plot')
-parser.add_argument('--log',
-                    dest='log',
-                    default=True,
-                    action='store_true',
-                    help='Turns log scale on')
-parser.add_argument('--no-log',
+parser.add_argument('--lin',
                     dest='log',
                     default=True,
                     action='store_false',
-                    help='Turns log scale off')
+                    help='Sets scale to linear. Default is log.')
 parser.add_argument('--vmin',
                     type=float,default=-4,
                     help='Colormap lower bound')
@@ -81,7 +76,6 @@ def make_snap(dfnam,vnam,coords,size,cmap,logplot,
 
   var = dump[vnam]
   if logplot:
-    print("logplot")
     var = np.log10(var)
 
   if IS_3D:


### PR DESCRIPTION
I made two major changes here. 

## Argparse

The first is that I have mapped `snap.py` to use `argparse` to aprse the argument list. This means it provides an automatically error-checking interface that maps cleanly to the standard `CLI` interface users expect on *nix systems. For example, on my machine, calling the function with no arguments produces:
```bash
(python3) jonahm@collapsar$ ~/programming/bhlight/script/analysis/snap.py
usage: snap.py [-h] [--coords {cart,mks}] [-s SIZE] [-l LOG] [--vmin VMIN]
               [--vmax VMAX] [-c CMAP] [--save SAVE]
               dumpfile variable
snap.py: error: the following arguments are required: dumpfile, variable
```

And if you call it with the help function, then it produces a more useful verbose help
```bash
(python3) jonahm@collapsar$ ~/programming/bhlight/script/analysis/snap.py -h
usage: snap.py [-h] [--coords {cart,mks}] [-s SIZE] [-l LOG] [--vmin VMIN]
               [--vmax VMAX] [-c CMAP] [--save SAVE]
               dumpfile variable

Plot 2d slices of your simulation at a given time.

positional arguments:
  dumpfile              File name to plot
  variable              Variable to plot

optional arguments:
  -h, --help            show this help message and exit
  --coords {cart,mks}   Coordinate system. Cartesian or Modified Kerr-Schild
  -s SIZE, --size SIZE  Size of domain to plot
  -l LOG, --log LOG     Log scale?
  --vmin VMIN           Colormap lower bound
  --vmax VMAX           Colormap upper bound
  -c CMAP, --cmap CMAP  Colormap used
  --save SAVE           Figure filename if you want to save the figure
```

And a call to the code looks like:
```bash
~/programming/bhlight/script/analysis/snap.py dump_00000092.h5 RHO --vmin=-6 --vmax 1 -c viridis -s 30
```

A nice feature of this is that the flags now are precessed by `--` and the parser automatically checks for type and available options, etc.

## `movie.py`

This change to `snap.py` broke `movie.py`. I fixed it by making `movie.py` use `argparse` as well. The way `movie` was originally designed, it was calling `snap.py` as a subprocess. I found this a little cumbersome, so I instead have `snap.py` provide a function that `movie` can import: `make_snap`. This way I can have `movie` use the `multiprocessing` pool to generate frames in parallel based on parsed arguments. The syntax looks something like this:

```python
dfnams = io.get_dumps_full(dfold)
hdr = io.load_hdr(dfnams[0])
geom = io.load_geom(hdr)
num_files = len(dfnams)

def make_frame(pair):
  i,d = pair
  print("frame %d/%d" % (i,num_files))
  make_snap(d,args.variable,args.coords,
            args.size,args.cmap,args.log,
            os.path.join(tmpdir,'frame_%08d.png' % i),
            args.vmin,args.vmax,
            geom=geom)

p = Pool()
p.map(make_frame,enumerate(dfnams))
```

Now movie generation is wicked fast and much more pythonic.