### PR TITLE
Updated I/O format to conform to standard

### DIFF
--- a/core/io.c
+++ b/core/io.c
@@ -646,16 +646,13 @@ void dump()
   int n_prim = NVAR; WRITE_HDR(n_prim, TYPE_INT);
   hdf5_write_str_list(vnams, "prim_names", file_id, STRLEN, NVAR);  
 
-  int my_test_int = 5;
-  write_scalar(&my_test_int, "my_test_int", TYPE_INT);
-
   WRITE_HDR(gam, TYPE_DBL);
   WRITE_HDR(cour, TYPE_DBL);
   WRITE_HDR(tf, TYPE_DBL);
   hdf5_add_units("tf", "code", file_id);
   #if ELECTRONS
-  WRITE_HDR(game, TYPE_DBL);
-  WRITE_HDR(gamp, TYPE_DBL);
+  double gam_e = game; WRITE_HDR(gam_e, TYPE_DBL);
+  double gam_p = gamp; WRITE_HDR(gam_p, TYPE_DBL);
   WRITE_HDR(tptemin, TYPE_DBL);
   WRITE_HDR(tptemax, TYPE_DBL);
   WRITE_HDR(fel0, TYPE_DBL);
@@ -701,9 +698,8 @@ void dump()
   hdf5_set_directory("/header/");
   #endif
 
-  hdf5_set_directory("/");
   hdf5_make_directory("geom", file_id);
-  hdf5_set_directory("/geom/");
+  hdf5_set_directory("/header/geom/");
   double startx1 = startx[1]; WRITE_HDR(startx1, TYPE_DBL);
   double startx2 = startx[2]; WRITE_HDR(startx2, TYPE_DBL);
   double startx3 = startx[3]; WRITE_HDR(startx3, TYPE_DBL);
@@ -713,42 +709,42 @@ void dump()
   int n_dim = NDIM; WRITE_HDR(n_dim, TYPE_INT);
   #if METRIC == MKS
   hdf5_make_directory("mks", file_id);
-  hdf5_set_directory("/geom/mks/");
-  double r_eh = Reh; WRITE_HDR(r_eh, TYPE_DBL);
-  hdf5_add_units("r_eh", "code", file_id);
-  double r_in = Rin; WRITE_HDR(r_in, TYPE_DBL);
-  hdf5_add_units("r_in", "code", file_id);
-  double r_isco = Risco; WRITE_HDR(r_isco, TYPE_DBL);
-  hdf5_add_units("r_isco", "code", file_id);
-  double r_out = Rout; WRITE_HDR(r_out, TYPE_DBL);
-  hdf5_add_units("r_out", "code", file_id);
+  hdf5_set_directory("/header/geom/mks/");
+  WRITE_HDR(Reh, TYPE_DBL);
+  hdf5_add_units("Reh", "code", file_id);
+  WRITE_HDR(Rin, TYPE_DBL);
+  hdf5_add_units("Rin", "code", file_id);
+  WRITE_HDR(Risco, TYPE_DBL);
+  hdf5_add_units("Risco", "code", file_id);
+  WRITE_HDR(Rout, TYPE_DBL);
+  hdf5_add_units("Rout", "code", file_id);
   WRITE_HDR(a, TYPE_DBL);
   WRITE_HDR(hslope, TYPE_DBL);
     #if RADIATION
-    double r_out_rad = Rout_rad; WRITE_HDR(r_out_rad, TYPE_DBL);
-    hdf5_add_units("r_out_rad", "code", file_id);
+    WRITE_HDR(Rout_rad, TYPE_DBL);
+    hdf5_add_units("Rout_rad", "code", file_id);
     #endif
   #endif
 
   #if METRIC == MMKS
   hdf5_make_directory("mmks", file_id);
-  hdf5_set_directory("/geom/mmks/");
-  double r_eh = Reh; WRITE_HDR(r_eh, TYPE_DBL);
-  hdf5_add_units("r_eh", "code", file_id);
-  double r_in = Rin; WRITE_HDR(r_in, TYPE_DBL);
-  hdf5_add_units("r_in", "code", file_id);
-  double r_isco = Risco; WRITE_HDR(r_isco, TYPE_DBL);
-  hdf5_add_units("r_isco", "code", file_id);
-  double r_out = Rout; WRITE_HDR(r_out, TYPE_DBL);
-  hdf5_add_units("r_out", "code", file_id);
+  hdf5_set_directory("/header/geom/mmks/");
+  WRITE_HDR(Reh, TYPE_DBL);
+  hdf5_add_units("Reh", "code", file_id);
+  WRITE_HDR(Rin, TYPE_DBL);
+  hdf5_add_units("Rin", "code", file_id);
+  WRITE_HDR(Risco, TYPE_DBL);
+  hdf5_add_units("Risco", "code", file_id);
+  WRITE_HDR(Rout, TYPE_DBL);
+  hdf5_add_units("Rout", "code", file_id);
   WRITE_HDR(a, TYPE_DBL);
   WRITE_HDR(hslope, TYPE_DBL);
   WRITE_HDR(poly_alpha, TYPE_DBL);
   WRITE_HDR(poly_xt, TYPE_DBL);
   WRITE_HDR(mks_smooth, TYPE_DBL);
     #if RADIATION
-    double r_out_rad = Rout_rad; WRITE_HDR(r_out_rad, TYPE_DBL);
-    hdf5_add_units("r_out_rad", "code", file_id);
+    WRITE_HDR(Rout_rad, TYPE_DBL);
+    hdf5_add_units("Rout_rad", "code", file_id);
     #endif
   #endif
  

--- a/core/io.c
+++ b/core/io.c
@@ -710,41 +710,41 @@ void dump()
   #if METRIC == MKS
   hdf5_make_directory("mks", file_id);
   hdf5_set_directory("/header/geom/mks/");
-  WRITE_HDR(Reh, TYPE_DBL);
-  hdf5_add_units("Reh", "code", file_id);
-  WRITE_HDR(Rin, TYPE_DBL);
-  hdf5_add_units("Rin", "code", file_id);
-  WRITE_HDR(Risco, TYPE_DBL);
-  hdf5_add_units("Risco", "code", file_id);
-  WRITE_HDR(Rout, TYPE_DBL);
-  hdf5_add_units("Rout", "code", file_id);
+  double r_eh = Reh; WRITE_HDR(r_eh, TYPE_DBL);
+  hdf5_add_units("r_eh", "code", file_id);
+  double r_in = Rin; WRITE_HDR(r_in, TYPE_DBL);
+  hdf5_add_units("r_in", "code", file_id);
+  double r_isco = Risco; WRITE_HDR(r_isco, TYPE_DBL);
+  hdf5_add_units("r_isco", "code", file_id);
+  double r_out = Rout; WRITE_HDR(r_out, TYPE_DBL);
+  hdf5_add_units("r_out", "code", file_id);
   WRITE_HDR(a, TYPE_DBL);
   WRITE_HDR(hslope, TYPE_DBL);
     #if RADIATION
-    WRITE_HDR(Rout_rad, TYPE_DBL);
-    hdf5_add_units("Rout_rad", "code", file_id);
+    double r_out_rad = Rout_rad; WRITE_HDR(r_out_rad, TYPE_DBL);
+    hdf5_add_units("r_out_rad", "code", file_id);
     #endif
   #endif
 
   #if METRIC == MMKS
   hdf5_make_directory("mmks", file_id);
   hdf5_set_directory("/header/geom/mmks/");
-  WRITE_HDR(Reh, TYPE_DBL);
-  hdf5_add_units("Reh", "code", file_id);
-  WRITE_HDR(Rin, TYPE_DBL);
-  hdf5_add_units("Rin", "code", file_id);
-  WRITE_HDR(Risco, TYPE_DBL);
-  hdf5_add_units("Risco", "code", file_id);
-  WRITE_HDR(Rout, TYPE_DBL);
-  hdf5_add_units("Rout", "code", file_id);
+  double r_eh = Reh; WRITE_HDR(r_eh, TYPE_DBL);
+  hdf5_add_units("r_eh", "code", file_id);
+  double r_in = Rin; WRITE_HDR(r_in, TYPE_DBL);
+  hdf5_add_units("r_in", "code", file_id);
+  double r_isco = Risco; WRITE_HDR(r_isco, TYPE_DBL);
+  hdf5_add_units("r_isco", "code", file_id);
+  double r_out = Rout; WRITE_HDR(r_out, TYPE_DBL);
+  hdf5_add_units("r_out", "code", file_id);
   WRITE_HDR(a, TYPE_DBL);
   WRITE_HDR(hslope, TYPE_DBL);
   WRITE_HDR(poly_alpha, TYPE_DBL);
   WRITE_HDR(poly_xt, TYPE_DBL);
   WRITE_HDR(mks_smooth, TYPE_DBL);
     #if RADIATION
-    WRITE_HDR(Rout_rad, TYPE_DBL);
-    hdf5_add_units("Rout_rad", "code", file_id);
+    double r_out_rad = Rout_rad; WRITE_HDR(r_out_rad, TYPE_DBL);
+    hdf5_add_units("r_out_rad", "code", file_id);
     #endif
   #endif
  

--- a/prob/torus/build.py
+++ b/prob/torus/build.py
@@ -5,12 +5,12 @@ PROB = 'torus'
                          ### COMPILE TIME PARAMETERS ###
 
 # SPATIAL RESOLUTION AND MPI DECOMPOSITION
-bhl.config.set_cparm('N1TOT', 240)
+bhl.config.set_cparm('N1TOT', 128)
 bhl.config.set_cparm('N2TOT', 128)
-bhl.config.set_cparm('N3TOT', 64)
-bhl.config.set_cparm('N1CPU', 4)
-bhl.config.set_cparm('N2CPU', 4)
-bhl.config.set_cparm('N3CPU', 4)
+bhl.config.set_cparm('N3TOT', 1)
+bhl.config.set_cparm('N1CPU', 1)
+bhl.config.set_cparm('N2CPU', 1)
+bhl.config.set_cparm('N3CPU', 1)
 
 # OPENMP PARALLELIZATION
 bhl.config.set_cparm('OPENMP', True)

--- a/script/analysis/hdf5_to_dict.py
+++ b/script/analysis/hdf5_to_dict.py
@@ -68,19 +68,19 @@ def load_hdr(fname):
 
 
   if hdr['METRIC'] == 'MKS':
-    hdr['Rin'] = read_scalar(dfile, '/header/geom/mks/Rin')
-    hdr['Rout'] = read_scalar(dfile, '/header/geom/mks/Rout')
-    hdr['Reh'] = read_scalar(dfile, '/header/geom/mks/Reh')
-    hdr['Risco'] = read_scalar(dfile, '/header/geom/mks/Risco')
+    hdr['Rin'] = read_scalar(dfile, '/header/geom/mks/r_in')
+    hdr['Rout'] = read_scalar(dfile, '/header/geom/mks/r_out')
+    hdr['Reh'] = read_scalar(dfile, '/header/geom/mks/r_eh')
+    hdr['Risco'] = read_scalar(dfile, '/header/geom/mks/r_isco')
     hdr['a'] = read_scalar(dfile, '/header/geom/mks/a')
     hdr['hslope'] = read_scalar(dfile, '/header/geom/mks/hslope')
     if hdr['RADIATION']:
       hdr['Rout_rad'] = read_scalar(dfile, '/header/geom/mks/r_out_rad')
   if hdr['METRIC'] == 'MMKS':
-    hdr['Rin'] = read_scalar(dfile, '/header/geom/mmks/Rin')
-    hdr['Rout'] = read_scalar(dfile, '/header/geom/mmks/Rout')
-    hdr['Reh'] = read_scalar(dfile, '/header/geom/mmks/Reh')
-    hdr['Risco'] = read_scalar(dfile, '/header/geom/mmks/Risco')
+    hdr['Rin'] = read_scalar(dfile, '/header/geom/mmks/r_in')
+    hdr['Rout'] = read_scalar(dfile, '/header/geom/mmks/r_out')
+    hdr['Reh'] = read_scalar(dfile, '/header/geom/mmks/r_eh')
+    hdr['Risco'] = read_scalar(dfile, '/header/geom/mmks/r_isco')
     hdr['a'] = read_scalar(dfile, '/header/geom/mmks/a')
     hdr['hslope'] = read_scalar(dfile, '/header/geom/mmks/hslope')
     hdr['poly_xt'] = read_scalar(dfile, '/header/geom/mmks/poly_xt')

--- a/script/analysis/hdf5_to_dict.py
+++ b/script/analysis/hdf5_to_dict.py
@@ -61,33 +61,33 @@ def load_hdr(fname):
   hdr['FLOORADV'] = '/header/has_flooradv' in dfile.keys()
   hdr['NVAR'] = read_scalar(dfile, '/header/n_prim')
   hdr['tf'] = read_scalar(dfile, '/header/tf')
-  hdr['startx'] = np.array([0, read_scalar(dfile, '/geom/startx1'),
-    read_scalar(dfile, '/geom/startx2'), read_scalar(dfile, '/geom/startx3')])
-  hdr['dx'] = np.array([0, read_scalar(dfile, '/geom/dx1'), read_scalar(dfile, '/geom/dx2'),
-    read_scalar(dfile, '/geom/dx3')])
+  hdr['startx'] = np.array([0, read_scalar(dfile, '/header/geom/startx1'),
+    read_scalar(dfile, '/header/geom/startx2'), read_scalar(dfile, '/header/geom/startx3')])
+  hdr['dx'] = np.array([0, read_scalar(dfile, '/header/geom/dx1'), read_scalar(dfile, '/header/geom/dx2'),
+    read_scalar(dfile, '/header/geom/dx3')])
 
 
   if hdr['METRIC'] == 'MKS':
-    hdr['Rin'] = read_scalar(dfile, '/geom/mks/r_in')
-    hdr['Rout'] = read_scalar(dfile, '/geom/mks/r_out')
-    hdr['Reh'] = read_scalar(dfile, '/geom/mks/r_eh')
-    hdr['Risco'] = read_scalar(dfile, '/geom/mks/r_isco')
-    hdr['a'] = read_scalar(dfile, '/geom/mks/a')
-    hdr['hslope'] = read_scalar(dfile, '/geom/mks/hslope')
+    hdr['Rin'] = read_scalar(dfile, '/header/geom/mks/Rin')
+    hdr['Rout'] = read_scalar(dfile, '/header/geom/mks/Rout')
+    hdr['Reh'] = read_scalar(dfile, '/header/geom/mks/Reh')
+    hdr['Risco'] = read_scalar(dfile, '/header/geom/mks/Risco')
+    hdr['a'] = read_scalar(dfile, '/header/geom/mks/a')
+    hdr['hslope'] = read_scalar(dfile, '/header/geom/mks/hslope')
     if hdr['RADIATION']:
-      hdr['Rout_rad'] = read_scalar(dfile, '/geom/mks/r_out_rad')
+      hdr['Rout_rad'] = read_scalar(dfile, '/header/geom/mks/r_out_rad')
   if hdr['METRIC'] == 'MMKS':
-    hdr['Rin'] = read_scalar(dfile, '/geom/mmks/r_in')
-    hdr['Rout'] = read_scalar(dfile, '/geom/mmks/r_out')
-    hdr['Reh'] = read_scalar(dfile, '/geom/mmks/r_eh')
-    hdr['Risco'] = read_scalar(dfile, '/geom/mmks/r_isco')
-    hdr['a'] = read_scalar(dfile, '/geom/mmks/a')
-    hdr['hslope'] = read_scalar(dfile, '/geom/mmks/hslope')
-    hdr['poly_xt'] = read_scalar(dfile, '/geom/mmks/poly_xt')
-    hdr['poly_alpha'] = read_scalar(dfile, '/geom/mmks/poly_alpha')
-    hdr['mks_smooth'] = read_scalar(dfile, '/geom/mmks/mks_smooth')
+    hdr['Rin'] = read_scalar(dfile, '/header/geom/mmks/Rin')
+    hdr['Rout'] = read_scalar(dfile, '/header/geom/mmks/Rout')
+    hdr['Reh'] = read_scalar(dfile, '/header/geom/mmks/Reh')
+    hdr['Risco'] = read_scalar(dfile, '/header/geom/mmks/Risco')
+    hdr['a'] = read_scalar(dfile, '/header/geom/mmks/a')
+    hdr['hslope'] = read_scalar(dfile, '/header/geom/mmks/hslope')
+    hdr['poly_xt'] = read_scalar(dfile, '/header/geom/mmks/poly_xt')
+    hdr['poly_alpha'] = read_scalar(dfile, '/header/geom/mmks/poly_alpha')
+    hdr['mks_smooth'] = read_scalar(dfile, '/header/geom/mmks/mks_smooth')
     if hdr['RADIATION']:
-      hdr['Rout_rad'] = read_scalar(dfile, '/geom/mmks/r_out_rad')
+      hdr['Rout_rad'] = read_scalar(dfile, '/header/geom/mmks/r_out_rad')
 
   hdr['gam'] = read_scalar(dfile, '/header/gam')
   hdr['cour'] = read_scalar(dfile, '/header/cour')
@@ -95,8 +95,8 @@ def load_hdr(fname):
   hdr['vnams'] = [h5_to_str(vnam) for vnam in read_scalar(dfile, '/header/prim_names')]
 
   if hdr['ELECTRONS']:
-    hdr['game'] = read_scalar(dfile, '/header/game')
-    hdr['gamp'] = read_scalar(dfile, '/header/gamp')
+    hdr['game'] = read_scalar(dfile, '/header/gam_e')
+    hdr['gamp'] = read_scalar(dfile, '/header/gam_p')
     hdr['tptemin'] = read_scalar(dfile, '/header/tptemin')
     hdr['tptemax'] = read_scalar(dfile, '/header/tptemax')
     hdr['fel0'] = read_scalar(dfile, '/header/fel0')


### PR DESCRIPTION
Modified `io.c` and `hdf5_to_dict.py` to conform to the [AFD-Illinois standard for GRMHD output](https://github.com/AFD-Illinois/iharm3d/wiki/Output-Format).

@gnwong @bprather would you mind taking a look at this, and merging if it looks good to you?