### PR TITLE
change how problem parameters are handled

### DIFF
--- a/core/decs.h
+++ b/core/decs.h
@@ -593,6 +593,7 @@ void mhd_vchar(double *pr, struct of_state *q, struct of_geom *geom, int js,
 
 // problem.c
 void set_problem_params();
+void save_problem_params();
 void init_prob();
 void bound_gas_prob_x1l(int i, int j, int k, grid_prim_type P);
 void bound_gas_prob_x1r(int i, int j, int k, grid_prim_type P);

--- a/core/decs.h
+++ b/core/decs.h
@@ -506,6 +506,7 @@ void interact(grid_prim_type P, double t, double dt);
 // input.c
 void init_params(char *pfname);
 void set_param(char *key, void *data);
+void set_param_optional(char *key, void *data);
 
 // io.c
 //void set_core_params();

--- a/core/input.c
+++ b/core/input.c
@@ -216,7 +216,7 @@ void read_params(char *pfname)
   #endif                                                                         
   
   if (mpi_io_proc()) {
-    fprintf(stderr, "Found %i,%i (required,optional) parameters, needed %i,%i.\n", 
+    fprintf(stderr, "Found %i,%i (required,optional) parameters, looked for %i,%i.\n", 
           nparamset-noptparamset, noptparamset, nparam-noptparam, noptparam);
     if (nparamset-noptparamset != nparam-noptparam && mpi_io_proc()) {
       fprintf(stderr, "! Incorrect number of required parameters set. Exiting.\n");
@@ -226,7 +226,7 @@ void read_params(char *pfname)
                                                                                  
   fclose(fp);                                                                    
                                                                                  
-  if (mpi_io_proc()) fprintf(stdout, "Parameter file read\n\n"); 
+  if (mpi_io_proc()) fprintf(stdout, "Parameter file read.\n\n"); 
 }
 
 void init_params(char *pfname)

--- a/core/input.c
+++ b/core/input.c
@@ -12,21 +12,34 @@
 struct param {
   char *key;
   void *data;
+  int required;
 };
 
 #define MAXPARAMS (1000)
 static struct param table[MAXPARAMS];
 static int nparam = 0;
+static int noptparam = 0;
 static int nparamset = 0;
+static int noptparamset = 0;
+
+void set_param_optional(char *key, void *data)
+{
+  table[nparam].key = key;
+  table[nparam].data = data;
+  table[nparam].required = 0;
+  nparam++;
+  noptparam++;
+}
 
 void set_param(char *key, void *data)
 {
   table[nparam].key = key;
   table[nparam].data = data;
+  table[nparam].required = 1;
   nparam++;
 }
 
-int get_param(char *key, void **data)
+int get_param(char *key, void **data, int *req)
 {
   int n = 0;
   while (strncmp(key, table[n].key, strlen(key)) != 0) {
@@ -37,6 +50,7 @@ int get_param(char *key, void **data)
     }
   }
   *data = table[n].data;
+  *req = table[n].required;
 
   return 1;
 }
@@ -170,25 +184,29 @@ void read_params(char *pfname)
     }                                                                            
                                                                                  
     // Read in parameter depending on datatype                                   
+    int req = 0;
     char type[6];                                                                
     strncpy(type, line, 5);                                                      
     type[5] = 0;                                                                 
-    if (get_param(key, &ptr)) {                                                  
+    if (get_param(key, &ptr, &req)) {
       if (!strncmp(type, "[int]", 5)) {                                          
         int buf;                                                                 
         sscanf(line, "%*s %s %*s %d", key, &buf);                                
         *((int*)ptr) = buf;                                                      
         nparamset++;                                                             
+        if (req == 0) noptparamset++;
       } else if (!strncmp(type, "[dbl]", 5)) {                                   
         double buf;                                                              
         sscanf(line, "%*s %s %*s %lf", key, &buf);                               
         *((double*)ptr) = buf;                                                   
         nparamset++;                                                             
+        if (req == 0) noptparamset++;
       } else if (!strncmp(type, "[str]", 5)) {                                   
         char buf[STRLEN];                                                        
         sscanf(line, "%*s %s %*s %s", key, buf);                                 
         strcpy((char*)ptr, buf);                                                 
         nparamset++;                                                             
+        if (req == 0) noptparamset++;
       }                                                                          
     }                                                                            
   }
@@ -196,10 +214,14 @@ void read_params(char *pfname)
   #if (METRIC == MKS || METRIC == MMKS) && RADIATION                                               
   Mbh = mbh*MSUN;                                                                
   #endif                                                                         
-                                                                                 
-  if (nparamset != nparam && mpi_io_proc()) {                                    
-    fprintf(stderr, "Set %i parameters, needed %i!\n", nparamset, nparam);       
-    exit(-1);                                                                    
+  
+  if (mpi_io_proc()) {
+    fprintf(stderr, "Found %i,%i (required,optional) parameters, needed %i,%i.\n", 
+          nparamset-noptparamset, noptparamset, nparam-noptparam, noptparam);
+    if (nparamset-noptparamset != nparam-noptparam && mpi_io_proc()) {
+      fprintf(stderr, "! Incorrect number of required parameters set. Exiting.\n");
+      exit(-1);
+    }
   }                                                                              
                                                                                  
   fclose(fp);                                                                    

--- a/core/io.h
+++ b/core/io.h
@@ -1,0 +1,60 @@
+#ifndef IO_H
+#define IO_H
+
+#include <hdf5.h>
+
+// global file pointer, defined in io.c
+extern hid_t file_id;
+
+// utilities for writing to an open file_id
+void hdf5_make_directory(const char *name);
+void hdf5_set_directory(const char *path);
+void write_scalar(void *data, const char *name, hsize_t type);
+void read_scalar(void *data, const char *name, hsize_t type);
+void write_array(void *data, const char *name, hsize_t rank,
+  hsize_t *fdims, hsize_t *fstart, hsize_t *fcount, hsize_t *mdims,
+  hsize_t *mstart, hsize_t type);
+void read_array(void *data, const char *name, hsize_t rank,
+  hsize_t *fdims, hsize_t *fstart, hsize_t *fcount, hsize_t *mdims,
+  hsize_t *mstart, hsize_t type);
+hsize_t product_hsize_t(hsize_t a[], int size);
+
+// some macro tricks to reduce the number of lines of code
+#define TYPE_FLOAT H5T_NATIVE_FLOAT
+#define TYPE_DBL H5T_NATIVE_DOUBLE
+#define TYPE_INT H5T_NATIVE_INT
+#define TYPE_STR H5T_NATIVE_CHAR
+
+#define WRITE_HDR(x, type) write_scalar((void*)&x, #x, type)
+#define READ_HDR(x, type) read_scalar((void*)&x, #x, type)
+
+#define WRITE_ARRAY(x, rank, fdims, fstart, fcount, mdims, mstart, type) \
+  write_array((void*)x, #x, rank, fdims, fstart, fcount, mdims, mstart, type)
+#define WRITE_GRID(x, name, type) write_array((void*)x, name, 3, fdims_grid, \
+  fstart_grid, fcount_grid, mdims_grid, mstart_grid, type)
+#define WRITE_GRID_NO_GHOSTS(x, type) write_array((void*)x, #x, 3, fdims_grid, \
+  fstart_grid, fcount_grid, mdims_grid_noghost, mstart_grid_noghost, type)
+#define WRITE_PRIM(x, name, type) write_array((void*)x, name, 4, fdims_prim, \
+  fstart_prim, fcount_prim, mdims_prim, mstart_prim, type)
+#define WRITE_VEC(x, type) write_array((void*)x, #x, 4, fdims_vec, \
+  fstart_vec, fcount_vec, mdims_vec, mstart_vec, type)
+#define WRITE_VEC_NO_GHOSTS(x, type) \
+  write_array((void*)x, #x, 4, fdims_vec, \
+  fstart_vec, fcount_vec, mdims_vec_noghost, mstart_vec_noghost, type)
+#define WRITE_TENSOR(x, type) write_array((void*)x, #x, 5, fdims_tens, \
+  fstart_tens, fcount_tens, mdims_tens, mstart_tens, type)
+#define WRITE_TENSOR_NO_GHOSTS(x, type) \
+  write_array((void*)x, #x, 5, fdims_tens,        \
+  fstart_tens, fcount_tens, mdims_tens_noghost, mstart_tens_noghost, type)
+#define READ_ARRAY(x, rank, fdims, fstart, fcount, mdims, mstart, type) \
+  read_array((void*)x, #x, rank, fdims, fstart, fcount, mdims, mstart, type)
+#define READ_GRID(x, type) read_array((void*)x, #x, 3, fdims_grid, \
+  fstart_grid, fcount_grid, mdims_grid, mstart_grid, type)
+#define READ_PRIM(x, type) read_array((void*)x, #x, 4, fdims_prim, \
+  fstart_prim, fcount_prim, mdims_prim, mstart_prim, type)
+#define READ_VEC(x, type) read_array((void*)x, #x, 4, fdims_vec, \
+  fstart_vec, fcount_vec, mdims_vec, mstart_vec, type)
+
+
+
+#endif // IO_H

--- a/core/main.c
+++ b/core/main.c
@@ -105,7 +105,9 @@ int main(int argc, char *argv[])
     init_core();
    
     // Set primitive variables
-    printf("Init from GRMHD? %i\n", strcmp(init_from_grmhd, "No") != 0);
+    if (mpi_io_proc()) {
+      fprintf(stderr, "Init from GRMHD? %i\n\n", strcmp(init_from_grmhd, "No") != 0);
+    }
     if (strcmp(init_from_grmhd, "No") == 0) { // Initialize from problem.c
       init_prob();
       #if ELECTRONS

--- a/core/push_superphotons.c
+++ b/core/push_superphotons.c
@@ -91,8 +91,6 @@ void push_superphotons(double dt)
         push_status = push_superphoton(ph, dtpush);
 
         if (push_status == PUSH_FAIL) {
-          printf("PUSH FAIL X[] = %e %e %e %e k.k\n", ph->X[2][0], ph->X[2][1], ph->X[2][2], ph->X[2][3]);
-          printf("PUSH FAIL K[] = %e %e %e %e k.k\n", ph->Kcon[2][0], ph->Kcon[2][1], ph->Kcon[2][2], ph->Kcon[2][3]);
           list_remove(&ph, &head, &prev);
           step_lost_local++;
           continue;

--- a/prob/bhtherm/problem.c
+++ b/prob/bhtherm/problem.c
@@ -12,7 +12,11 @@
 
 double *r_init, *P_cgs_init, *rho_cgs_init;
 
-void set_problem_params() {
+void set_problem_params() 
+{ 
+}
+void save_problem_params() 
+{ 
 }
 
 void init_zone_thermal(int i, int j, int k, double dndlnu[NU_BINS_EMISS+1]);

--- a/prob/bondi/problem.c
+++ b/prob/bondi/problem.c
@@ -15,6 +15,9 @@ double lfish_calc(double rmax) ;
 void set_problem_params()
 {
 }
+void save_problem_params()
+{
+}
 
 // Rootfinding for analytic Bondi solution
 #include <gsl/gsl_errno.h>

--- a/prob/brem/problem.c
+++ b/prob/brem/problem.c
@@ -8,11 +8,17 @@
 
 #include "decs.h"
 
+#include "io.h"
+
 // Problem-specific variables to set at runtime
 static double T0;
 void set_problem_params()
 {
   set_param("T0", &T0);
+}
+void save_problem_params()
+{
+  WRITE_HDR(T0, TYPE_DBL);
 }
 
 void init_prob()

--- a/prob/comptonization/problem.c
+++ b/prob/comptonization/problem.c
@@ -12,6 +12,9 @@
 void set_problem_params()
 {
 }
+void save_problem_params()
+{
+}
 
 // Initialize dynamical variables
 void init_prob()

--- a/prob/entropy/problem.c
+++ b/prob/entropy/problem.c
@@ -13,6 +13,9 @@ void set_problem_params()
 {
   //set_param("tscale", &tscale);
 }
+void save_problem_params()
+{
+}
 
 void init_prob()
 {

--- a/prob/kshocks/problem.c
+++ b/prob/kshocks/problem.c
@@ -7,11 +7,16 @@
  ******************************************************************************/
 
 #include "decs.h"
+#include "io.h"
 
 static int shock;
 void set_problem_params()
 {
   set_param("shock", &shock);
+}
+void save_problem_params()
+{ 
+  WRITE_HDR(shock, TYPE_INT);
 }
 
 void init_prob()

--- a/prob/mhdmodes1d/problem.c
+++ b/prob/mhdmodes1d/problem.c
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "decs.h"
+#include "io.h"
 #include <complex.h>
 
 static int nmode;
@@ -15,6 +16,11 @@ void set_problem_params()
 {
   set_param("nmode", &nmode);
   set_param("idim",&idim);
+}
+void save_problem_params()
+{
+  WRITE_HDR(nmode, TYPE_INT);
+  WRITE_HDR(idim, TYPE_INT);
 }
 
 void init_prob()

--- a/prob/mhdmodes2d/problem.c
+++ b/prob/mhdmodes2d/problem.c
@@ -7,12 +7,17 @@
  ******************************************************************************/
 
 #include "decs.h"
+#include "io.h"
 #include <complex.h>
 
 static int nmode;
 void set_problem_params()
 {
   set_param("nmode", &nmode);
+}
+void save_problem_params()
+{
+  WRITE_HDR(nmode, TYPE_INT);
 }
 
 void init_prob()

--- a/prob/mhdmodes3d/problem.c
+++ b/prob/mhdmodes3d/problem.c
@@ -7,12 +7,17 @@
  ******************************************************************************/
 
 #include "decs.h"
+#include "io.h"
 #include <complex.h>
 
 static int nmode;
 void set_problem_params()
 {
   set_param("nmode", &nmode);
+}
+void save_problem_params() 
+{
+  WRITE_HDR(nmode, TYPE_INT);
 }
 
 void init_prob()

--- a/prob/sod/problem.c
+++ b/prob/sod/problem.c
@@ -7,11 +7,16 @@
  ******************************************************************************/
 
 #include "decs.h"
+#include "io.h"
 
 static double tscale;
 void set_problem_params()
 {
   set_param("tscale", &tscale);
+}
+void save_problem_params()
+{
+  WRITE_HDR(tscale, TYPE_DBL);
 }
 
 void init_prob()

--- a/prob/sound/problem.c
+++ b/prob/sound/problem.c
@@ -13,6 +13,9 @@ void set_problem_params()
 {
   //set_param("tscale", &tscale);
 }
+void save_problem_params() 
+{
+}
 
 void init_prob()
 {

--- a/prob/thermalization/problem.c
+++ b/prob/thermalization/problem.c
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "decs.h"
+#include "io.h"
 
 // Problem-specific variables to set at runtime
 static double T0, ne;
@@ -14,6 +15,11 @@ void set_problem_params()
 {
   set_param("T0", &T0);
   set_param("ne", &ne);
+}
+void save_problem_params()
+{
+  WRITE_HDR(T0, TYPE_DBL);
+  WRITE_HDR(ne, TYPE_DBL);
 }
 
 // Initialize dynamical variables 

--- a/prob/torus/build.py
+++ b/prob/torus/build.py
@@ -60,6 +60,8 @@ bhl.config.set_cparm('X3R_RAD_BOUND', 'BC_PERIODIC')
 
 bhl.config.set_rparm('tf', 'double', default = 30001)
 bhl.config.set_rparm('dt', 'double', default = 1.e-6)
+bhl.config.set_rparm('rin', 'double', default = 20)     # MEDIUM_DISK 10
+bhl.config.set_rparm('rmax', 'double', default = 41)    # MEDIUM_DISK 20
 bhl.config.set_rparm('Rout', 'double', default = 1000.)
 bhl.config.set_rparm('Rout_rad', 'double', default = 40.)
 bhl.config.set_rparm('gam', 'double', default = 13./9.)
@@ -70,6 +72,7 @@ bhl.config.set_rparm('DNr', 'integer', default = 1000)
 bhl.config.set_rparm('a', 'double', default = 0.9375)
 bhl.config.set_rparm('mbh', 'double', default = 1.e8)
 bhl.config.set_rparm('M_unit', 'double', default = 8.e23)
+bhl.config.set_rparm('u_jitter', 'double', default = 0.04)
 bhl.config.set_rparm('tune_emiss', 'double', 1.0)
 bhl.config.set_rparm('tune_scatt', 'double', 0.1)
 bhl.config.set_rparm('t0_tune_emiss', 'double', 500)

--- a/prob/torus/problem.c
+++ b/prob/torus/problem.c
@@ -20,11 +20,23 @@ double lfish_calc(double rmax) ;
 static int MAD;
 static double BHflux;
 static double beta;
+static double u_jitter;
+static double rin;
+static double rmax;
 void set_problem_params()
 {
+  // register required parameters
   set_param("MAD", &MAD);
   set_param("BHflux", &BHflux);
   set_param("beta", &beta);
+  
+  // register optional parameters
+  set_param_optional("u_jitter", &u_jitter);
+  set_param_optional("rin", &rin);
+  set_param_optional("rmax", &rmax);
+ 
+  // set defaults for optional parameters
+  u_jitter = 4.e-2;
 }
 
 void init_prob()
@@ -32,17 +44,20 @@ void init_prob()
   double r, th, sth, cth, ur, uh, up, u, rho, X[NDIM];
   struct of_geom *geom;
 
+  printf(" we have %g %g %g\n", u_jitter, rin, rmax );
+
   // Disk interior
-  double l, rin, lnh, expm2chi, up1, DD, AA, SS, thin, sthin, cthin, DDin, AAin;
+  double l, lnh, expm2chi, up1, DD, AA, SS, thin, sthin, cthin, DDin, AAin;
   double SSin, kappa, hm1;
 
   // Magnetic field
   static double A[N1+2*NG][N2+2*NG];
-  double rho_av, rhomax, umax, /*beta, */bsq_ij, bsq_max, q, rmax, Nloops;//, rstart;
+  double rho_av, rhomax, umax, /*beta, */bsq_ij, bsq_max, q, Nloops;//, rstart;
   //double rend;
 
   // Fishbone-Moncrief parameters
   if (N3 == 1) {
+    fprintf(stderr, "! N3=1, defaulting to MAD=1 initial configuration.\n");
     MAD = 1; // SANE initial field not supported in 2D
     rin = 6.;
     rmax = 12.;
@@ -174,7 +189,7 @@ void init_prob()
 
       P[i][j][k][RHO] = rho;
       if (rho > rhomax) rhomax = rho;
-      P[i][j][k][UU] = u * (1. + 4.e-2 * (get_rand() - 0.5));
+      P[i][j][k][UU] = u * (1. + u_jitter * (get_rand() - 0.5));
       if (u > umax && r > rin) umax = u;
       P[i][j][k][U1] = ur;
       P[i][j][k][U2] = uh;

--- a/prob/torus/problem.c
+++ b/prob/torus/problem.c
@@ -315,9 +315,9 @@ void init_prob()
     if (mpi_nprocs() > 1) {
       if (mpi_io_proc())
         fprintf(stdout, "MPI nodes > 1: Using hard-coded loop normalization!\n");
-      //rstart = 2.335894e+01;
+      //rstart = 2.335894e+01;    // These numbers for (20,41)
       //rend = 3.737892e+02;
-      rstart = 1.175453e+01;
+      rstart = 1.175453e+01;    // These numbers for MEDIUM_DISK (10,20)
       rend = 8.362236e+01 ;
     } else {
       printf("rstart = %e rend = %e\n", rstart, rend);

--- a/prob/torus/problem.c
+++ b/prob/torus/problem.c
@@ -8,6 +8,8 @@
 
 #include "decs.h"
 
+#include "io.h"
+
 #define CLASSIC_BFIELD (0)
 #define LOW_FLUX (1)
 
@@ -41,6 +43,25 @@ void set_problem_params()
   u_jitter = 4.e-2;
   rin = 20.;
   rmax = 41.;
+}
+
+void save_problem_params()
+{
+  hdf5_make_directory("macros");
+  int tmp = CLASSIC_BFIELD;
+  write_scalar(&tmp, "macros/CLASSIC_BFIELD", TYPE_INT);
+  tmp = LOW_FLUX;
+  write_scalar(&tmp, "macros/LOW_FLUX", TYPE_INT);
+  tmp = NO_BFIELD;
+  write_scalar(&tmp, "macros/NO_BFIELD", TYPE_INT);
+
+  WRITE_HDR(MAD, TYPE_INT);
+  WRITE_HDR(BHflux, TYPE_DBL);
+  WRITE_HDR(beta, TYPE_DBL);
+
+  WRITE_HDR(u_jitter, TYPE_DBL);
+  WRITE_HDR(rin, TYPE_DBL);
+  WRITE_HDR(rmax, TYPE_DBL);
 }
 
 void init_prob()

--- a/script/machine/bh.py
+++ b/script/machine/bh.py
@@ -1,0 +1,34 @@
+################################################################################
+#                                                                              #
+#  MACHINE-SPECIFIC FUNCTIONS                                                  #
+#                                                                              #
+#    OPTIONS:                                                                  #
+#      COMPILER   : PATH TO COMPILER EXECUTABLE                                #
+#      GSL_DIR    : PATH TO GSL INSTALLATION                                   #
+#      MPI_DIR    : PATH TO MPI INSTALLATION                                   #
+#      HDF5_DIR   : PATH TO HDF5 INSTALLATION                                  #
+#      EXECUTABLE : BINARY WRAPPER USED TO LAUNCH BHLIGHT                      #
+#                                                                              #
+#    MPI_DIR AND HDF5_DIR ARE NOT REQUIRED IF COMPILER HANDLES HEADERS AND     #
+#    LIBRARIES FOR THESE DEPENDENCIES                                          #
+#                                                                              #
+################################################################################
+
+import os
+
+def matches_host():                                                              
+  host = os.uname()[1]                                                           
+  return host == 'bh'
+
+def get_options():
+  host = {}
+
+  host['NAME']           = os.uname()[1]
+  host['COMPILER']       = '/usr/lib64/mpi/gcc/openmpi/bin/h5pcc'
+  host['COMPILER_FLAGS'] = '-O3 -Werror -fopenmp'
+  host['DEBUG_FLAGS']    = '-g -O0 -Wall -fopenmp'
+  host['GSL_DIR']        = ''
+  host['EXECUTABLE']     = ''
+
+  return host
+


### PR DESCRIPTION
This pull request is based around making it easier to glean both compile- and run- time information from the dump files. Two main structural changes were made:

1) ```ebhlight``` now accepts "optional" runtime parameters. These optional parameters are identified in the same ```problem.c:set_problem_params()``` place and registered with the ```set_param_optional(char *key, void *data);``` function. Default values should be specified in the same ```set_problem_params()``` function.

2) Parameters used in the ```problem.c``` files are now saved into the hdf5 dumps according to the content of the ```problem.c:save_problem_params()``` function. After including the ```io.h``` header file which exposes an interface to writing to (an open) hdf5 file, the developer can specify any quantities of interest (e.g., in the case of the torus problem, ```MAD```, ```rin```, and ```rmax```) that they want to be saved to the hdf5 dump files within this function. The easiest interface is likely to simply use the ```WRITE_HDR(variable, TYPE_{INT,DBL,STR});``` macro. This function gets called during the ```io.c:dump()``` call which occurs in ```diag.c```.

