### PR TITLE
bugfix/units

### DIFF
--- a/core/decs.h
+++ b/core/decs.h
@@ -637,7 +637,7 @@ int push_to_X_K(double t, struct of_photon *ph, double X[NDIM],
   double Kcov[NDIM], double Kcon[NDIM]);
 int to_be_pushed(double t, double dt, struct of_photon *ph);
 void swap_ph(struct of_photon **donor, struct of_photon **recipient);
-void get_nuLnu_bin(double X[NDIM], int *thbin, int *phibin);
+double get_nuLnu_bin(double X[NDIM], int *thbin, int *phibin);
 #endif
 
 // radiation.c

--- a/core/defs.h
+++ b/core/defs.h
@@ -28,7 +28,6 @@ grid_double_type nph;
 struct of_photon **photon_lists;
 struct of_photon **photon_mpi_lists;
 double nuLnu[MAXNSCATT+1][NTH][NPHI][NU_BINS_SPEC];
-//double dOmega[N2+2*NG][N3+2*NG];
 double Jrad[MAXNSCATT+2][N1+2*NG][N2+2*NG][N3+2*NG];
 double Jrad_buf[MAXNSCATT+2][N1+2*NG][N2+2*NG][N3+2*NG];
 grid_int_type Nem, Nabs, Nsc;

--- a/core/diag.c
+++ b/core/diag.c
@@ -382,13 +382,13 @@ void record_superphoton(double X[NDIM], struct of_photon *ph)
   double nu = -ph->Kcov[2][0]*ME*CL*CL/HPL;
 
   int thbin, phibin, nubin = (log(nu) - lnumin)/dlnu;
-  get_nuLnu_bin(X, &thbin, &phibin);
+  double dOmega = get_nuLnu_bin(X, &thbin, &phibin);
 
   // Store dE / dlognu dOmega dt
   if (nubin >= 0 && nubin < NU_BINS_SPEC) {
     #pragma omp atomic
     nuLnu[nscatt][thbin][phibin][nubin] -= ph->w*ph->Kcov[2][0]*ME*CL*CL/
-                                  (dlnu*DTd*T_unit);
+                                  (dlnu*DTd*T_unit) * 4.*M_PI / dOmega;
     #pragma omp atomic
     step_rec++;
   }

--- a/core/interact.c
+++ b/core/interact.c
@@ -216,7 +216,7 @@ void interact(grid_prim_type P, double t, double dt)
           
           // du_e / dtau
           #pragma omp atomic
-          Jrad[1][i][j][k] += dot(Ucon_grid[i][j][k], Gcov);
+          Jrad[1][i][j][k] += dot(Ucon_grid[i][j][k], Gcov) * dt/DTd;
 
           step_abs_local++;
 
@@ -307,7 +307,7 @@ void interact(grid_prim_type P, double t, double dt)
           // du_e / dtau
           int nscatt = MY_MIN(ph->nscatt, MAXNSCATT - 1);
           #pragma omp atomic
-          Jrad[nscatt+2][i][j][k] += dot(Ucon_grid[i][j][k], Gcov);
+          Jrad[nscatt+2][i][j][k] += dot(Ucon_grid[i][j][k], Gcov) * dt/DTd;
           
           //push phscatt as far as possible
           status = push_superphoton(phscatt, cour*dt_light[i][j]);

--- a/core/make_superphotons.c
+++ b/core/make_superphotons.c
@@ -202,7 +202,7 @@ void sample_photon(int i, int j, int k, double t, double dt,
 
     // du_e / dtau
     #pragma omp atomic
-    Jrad[0][i][j][k] -= dot(Ucon, Gcov) * dt / DTd;
+    Jrad[0][i][j][k] -= dot(Ucon, Gcov) * dt/DTd;
 
     #pragma omp atomic
     Nem[i][j][k] += 1;

--- a/core/make_superphotons.c
+++ b/core/make_superphotons.c
@@ -202,7 +202,7 @@ void sample_photon(int i, int j, int k, double t, double dt,
 
     // du_e / dtau
     #pragma omp atomic
-    Jrad[0][i][j][k] -= dot(Ucon, Gcov);
+    Jrad[0][i][j][k] -= dot(Ucon, Gcov) * dt / DTd;
 
     #pragma omp atomic
     Nem[i][j][k] += 1;

--- a/core/rad_utils.c
+++ b/core/rad_utils.c
@@ -480,7 +480,7 @@ void set_Rmunu()
 	} // omp parallel
 }
 
-void get_nuLnu_bin(double X[NDIM], int *thbin, int *phibin)
+double get_nuLnu_bin(double X[NDIM], int *thbin, int *phibin)
 {
   double r, th, phi;
   bl_coord(X, &r, &th); 
@@ -492,6 +492,10 @@ void get_nuLnu_bin(double X[NDIM], int *thbin, int *phibin)
 
   *thbin = (int)(phi/dphi);
   *phibin = (int)(th/dth);
+
+  return 2.*M_PI*(-cos((*thbin+1)*dth) + cos((*thbin)*dth)) / NPHI;
+
 }
+
 #endif // RADIATION
 

--- a/core/rad_utils.c
+++ b/core/rad_utils.c
@@ -490,8 +490,8 @@ double get_nuLnu_bin(double X[NDIM], int *thbin, int *phibin)
   double dth = M_PI/NTH;
   double dphi = 2.*M_PI/NPHI;
 
-  *thbin = (int)(phi/dphi);
-  *phibin = (int)(th/dth);
+  *thbin = (int)(th/dth);
+  *phibin = (int)(phi/dphi);
 
   return 2.*M_PI*(-cos((*thbin+1)*dth) + cos((*thbin)*dth)) / NPHI;
 

--- a/script/analysis/spec.py
+++ b/script/analysis/spec.py
@@ -28,11 +28,11 @@ if freq is not None:
   print(dump['nuLnu'].shape)
   nuLnu = dump['nuLnu'].sum(axis=0).sum(axis=-2)
   for n in range(hdr['nth']):
-    print(np.interp(freq, nu, nuLnu[n,:])*4*np.pi/hdr['dOmega'][n,:].sum(axis=-1))
+    print(np.interp(freq, nu, nuLnu[n,:]))
     print(n)
 
 fig, ax = plt.subplots(1, 1, figsize=(10,10))
-nuLnu = dump['nuLnu'].sum(axis=0).sum(axis=0).sum(axis=0)
+nuLnu = dump['nuLnu'].sum(axis=0).mean(axis=(0,1))
 ax.step(nu, nuLnu, where='mid', color='k')
 ax.set_xscale('log'); ax.set_yscale('log')
 maxL = nuLnu.max()


### PR DESCRIPTION
This pull request contains two general changes:

1) Change normalization in nuLnu to be "per th/phi bin" to "per spherical shell". The latter is the standard convention. In practice, this means multiplying each photon recording event by 4pi / dOmega where dOmega is the solid angle subtended by the th/phi bin. This solid angle is now returned as a double by the ```get_nuLnu_bin(...)``` function. This change also swaps (and thus fixes) the assignment of ```thbin``` and ```phibin``` within ```get_nuLnu_bin(...)```. This change required a modification of the ```spec.py``` analysis script.

2) Fix scale factor in ```Jrad``` to be code energy/volume/time. Because ```Jrad``` is only zeroed once per dump, it needs to be divided by ```DTd``` (dump cadence in code time). Further, because of the way sampling is done for the radiation ```Gcov```, we _also_ need to multiply the quantity by the step length ```dt``` (in code time) for proper scaling. For reference, notice how ```Gcov``` contributes to the change in zone internal energy ```uu``` via ```radG```. 

